### PR TITLE
Added PropertyGrid CanChange Binding

### DIFF
--- a/CHANGELOG_IUEDITOR.md
+++ b/CHANGELOG_IUEDITOR.md
@@ -11,6 +11,9 @@ The "Master" Branch will always be synced to the official Codeplex Version.
 
 ## History
 
+* 2017-11-22
+	* added EditorEnabled dependency property in PropertyGrid for CanChange function
+
 * 2017-10-20
 	* property grid clear button image change / border color  
 	* wizard button style add (binding) 

--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/ContainerHelperBase.cs
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/ContainerHelperBase.cs
@@ -197,6 +197,7 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid
     public virtual void NotifyPropertyDefinitionsCollectionChanged() { }
 
     public abstract void UpdateValuesFromSource();
+        public abstract void UpdateEditorEnabledFromSource();// IUEditor
 
     protected internal virtual void SetPropertiesExpansion( bool isExpanded )
     {

--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/ContainerHelperBase.cs
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/ContainerHelperBase.cs
@@ -198,7 +198,7 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid
 
     public abstract void UpdateValuesFromSource();
         #region IUEditor
-        public abstract void UpdateEditorEnabledFromSource();
+        public abstract void UpdateIsEnabledFromSource();
         #endregion // IUEditor
 
     protected internal virtual void SetPropertiesExpansion( bool isExpanded )

--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/ContainerHelperBase.cs
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/ContainerHelperBase.cs
@@ -197,7 +197,9 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid
     public virtual void NotifyPropertyDefinitionsCollectionChanged() { }
 
     public abstract void UpdateValuesFromSource();
-        public abstract void UpdateEditorEnabledFromSource();// IUEditor
+        #region IUEditor
+        public abstract void UpdateEditorEnabledFromSource();
+        #endregion // IUEditor
 
     protected internal virtual void SetPropertiesExpansion( bool isExpanded )
     {

--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/DescriptorPropertyDefinition.cs
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/DescriptorPropertyDefinition.cs
@@ -107,6 +107,46 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid
 
       return binding;
     }
+        // IUEditor start
+
+        private const string ENABLED_PREFIX = "IsEnabled"; // IsEnabled[PropertyName]
+        /// <summary>
+        /// Gives SelectedObject's enabled property name, if exists
+        /// </summary>
+        /// <returns>if exist, enabled property name (IsEnabledPropertyName) / null otherwise.</returns>
+        public override string EditorEnabledPropertyName()
+        {
+            var selectedObject = SelectedObject;
+            string enabledPropertyName = ENABLED_PREFIX + PropertyDescriptor.Name;
+            bool hasEnabledProperty = selectedObject.GetType().GetProperty(enabledPropertyName) != null;
+            if (hasEnabledProperty)
+            {
+                return enabledPropertyName;
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Gives Binding for EditorEnabled property, only if it exists in selected object
+        /// </summary>
+        /// <returns>if exist, Binding object with source(selectedObject) and enabled property(IsEnabledPropertyName) / null otherwise.</returns>
+        protected override BindingBase CreateEditorEnabledBinding()
+        {
+            var selectedObject = SelectedObject;
+            string enabledPropertyName = EditorEnabledPropertyName();
+            if (enabledPropertyName == null)
+            {
+                return null;
+            }
+
+            var binding = new Binding(enabledPropertyName)
+            {
+                Source = this.GetValueInstance(selectedObject),
+                Mode = BindingMode.OneWay
+            };
+            return binding;
+        }
+        // IUEditor end
 
     protected override bool ComputeIsReadOnly()
     {

--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/DescriptorPropertyDefinition.cs
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/DescriptorPropertyDefinition.cs
@@ -107,8 +107,8 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid
 
       return binding;
     }
-        // IUEditor start
 
+        #region IUEditor
         private const string ENABLED_PREFIX = "IsEnabled"; // IsEnabled[PropertyName]
         /// <summary>
         /// Gives SelectedObject's enabled property name, if exists
@@ -146,8 +146,8 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid
             };
             return binding;
         }
-        // IUEditor end
-
+        #endregion IUEditor
+    
     protected override bool ComputeIsReadOnly()
     {
       return PropertyDescriptor.IsReadOnly;

--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/DescriptorPropertyDefinition.cs
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/DescriptorPropertyDefinition.cs
@@ -114,7 +114,7 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid
         /// Gives SelectedObject's enabled property name, if exists
         /// </summary>
         /// <returns>if exist, enabled property name (IsEnabledPropertyName) / null otherwise.</returns>
-        public override string EditorEnabledPropertyName()
+        public override string IsEnabledPropertyName()
         {
             var selectedObject = SelectedObject;
             string enabledPropertyName = ENABLED_PREFIX + PropertyDescriptor.Name;
@@ -127,13 +127,13 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid
         }
 
         /// <summary>
-        /// Gives Binding for EditorEnabled property, only if it exists in selected object
+        /// Gives Binding for IsEnabled property, only if it exists in selected object
         /// </summary>
         /// <returns>if exist, Binding object with source(selectedObject) and enabled property(IsEnabledPropertyName) / null otherwise.</returns>
-        protected override BindingBase CreateEditorEnabledBinding()
+        protected override BindingBase CreateIsEnabledBinding()
         {
             var selectedObject = SelectedObject;
-            string enabledPropertyName = EditorEnabledPropertyName();
+            string enabledPropertyName = IsEnabledPropertyName();
             if (enabledPropertyName == null)
             {
                 return null;

--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/DescriptorPropertyDefinitionBase.cs
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/DescriptorPropertyDefinitionBase.cs
@@ -129,6 +129,11 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid
 
     protected abstract BindingBase CreateValueBinding();
 
+        // IUEditor start
+        protected abstract BindingBase CreateEditorEnabledBinding();
+        public abstract string EditorEnabledPropertyName();
+        // IUEditor end
+
     #endregion
 
     #region Internal Methods
@@ -231,6 +236,17 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid
         bindingExpr.UpdateTarget();
       }
     }
+
+        // IUEditor start
+        internal void UpdateEditorEnabledFromSource()
+        {
+            var bindingExpr = BindingOperations.GetBindingExpressionBase(this, EditorEnabledProperty);
+            if (bindingExpr != null)
+            {
+                bindingExpr.UpdateTarget();
+            }
+        }
+        // IUEditor end
 
 
 
@@ -614,6 +630,26 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid
 
     #endregion //Value Property
 
+
+        // IUEditor Start
+        #region Enabled Property (DP)
+        public static readonly DependencyProperty EditorEnabledProperty = DependencyProperty.Register("EditorEnabled", typeof(bool), typeof(DescriptorPropertyDefinitionBase), new FrameworkPropertyMetadata(true, OnEditorEnabledChanged));
+        public bool EditorEnabled
+        {
+            get => (bool)GetValue(EditorEnabledProperty);
+            set => SetValue(EditorEnabledProperty, value);
+        }
+        private static void OnEditorEnabledChanged(DependencyObject o, DependencyPropertyChangedEventArgs e)
+        {
+            ((DescriptorPropertyDefinitionBase)o).OnEditorEnabledChanged((bool)e.OldValue, (bool)e.NewValue);
+        }
+        internal virtual void OnEditorEnabledChanged(bool oldValue, bool newValue)
+        {
+            // todo: Is this necessary? remove if not
+        }
+        #endregion // Enabled Property
+        // IUEditor End
+
     public virtual void InitProperties()
     {
       // Do "IsReadOnly" and PropertyName first since the others may need that value.
@@ -636,6 +672,25 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid
 
       BindingBase valueBinding = this.CreateValueBinding();
       BindingOperations.SetBinding( this, DescriptorPropertyDefinitionBase.ValueProperty, valueBinding );
+
+            // IUEditor start
+            Console.WriteLine("InitProperties - enabledBinding Begin");
+            BindingBase enabledBinding = this.CreateEditorEnabledBinding();
+            if (enabledBinding != null)
+            {
+                Console.WriteLine("InitProperties - enabledBinding not null:" + enabledBinding.ToString());
+                try
+                {
+                    BindingOperations.SetBinding(this, DescriptorPropertyDefinitionBase.EditorEnabledProperty, enabledBinding);
+                }
+                catch(Exception e)
+                {
+                    Console.WriteLine("SetBinding Error for property " + PropertyName);
+                    Console.WriteLine( e.StackTrace );
+                }
+            }
+            Console.WriteLine("InitProperties - enabledBinding End");
+            // IUEditor end
     }
 
 

--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/DescriptorPropertyDefinitionBase.cs
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/DescriptorPropertyDefinitionBase.cs
@@ -633,19 +633,11 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid
 
         // IUEditor Start
         #region Enabled Property (DP)
-        public static readonly DependencyProperty EditorEnabledProperty = DependencyProperty.Register("EditorEnabled", typeof(bool), typeof(DescriptorPropertyDefinitionBase), new FrameworkPropertyMetadata(true, OnEditorEnabledChanged));
+        public static readonly DependencyProperty EditorEnabledProperty = DependencyProperty.Register("EditorEnabled", typeof(bool), typeof(DescriptorPropertyDefinitionBase), new UIPropertyMetadata(true));
         public bool EditorEnabled
         {
             get => (bool)GetValue(EditorEnabledProperty);
             set => SetValue(EditorEnabledProperty, value);
-        }
-        private static void OnEditorEnabledChanged(DependencyObject o, DependencyPropertyChangedEventArgs e)
-        {
-            ((DescriptorPropertyDefinitionBase)o).OnEditorEnabledChanged((bool)e.OldValue, (bool)e.NewValue);
-        }
-        internal virtual void OnEditorEnabledChanged(bool oldValue, bool newValue)
-        {
-            // todo: Is this necessary? remove if not
         }
         #endregion // Enabled Property
         // IUEditor End

--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/DescriptorPropertyDefinitionBase.cs
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/DescriptorPropertyDefinitionBase.cs
@@ -666,22 +666,11 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid
       BindingOperations.SetBinding( this, DescriptorPropertyDefinitionBase.ValueProperty, valueBinding );
 
             // IUEditor start
-            Console.WriteLine("InitProperties - enabledBinding Begin");
             BindingBase enabledBinding = this.CreateEditorEnabledBinding();
             if (enabledBinding != null)
             {
-                Console.WriteLine("InitProperties - enabledBinding not null:" + enabledBinding.ToString());
-                try
-                {
-                    BindingOperations.SetBinding(this, DescriptorPropertyDefinitionBase.EditorEnabledProperty, enabledBinding);
-                }
-                catch(Exception e)
-                {
-                    Console.WriteLine("SetBinding Error for property " + PropertyName);
-                    Console.WriteLine( e.StackTrace );
-                }
+                BindingOperations.SetBinding(this, DescriptorPropertyDefinitionBase.EditorEnabledProperty, enabledBinding);
             }
-            Console.WriteLine("InitProperties - enabledBinding End");
             // IUEditor end
     }
 

--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/DescriptorPropertyDefinitionBase.cs
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/DescriptorPropertyDefinitionBase.cs
@@ -130,8 +130,8 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid
     protected abstract BindingBase CreateValueBinding();
 
         #region IUEditor
-        protected abstract BindingBase CreateEditorEnabledBinding();
-        public abstract string EditorEnabledPropertyName();
+        protected abstract BindingBase CreateIsEnabledBinding();
+        public abstract string IsEnabledPropertyName();
         #endregion // IUEditor
 
     #endregion // Virtual Methods
@@ -238,9 +238,9 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid
     }
 
         #region IUEditor
-        internal void UpdateEditorEnabledFromSource()
+        internal void UpdateIsEnabledFromSource()
         {
-            var bindingExpr = BindingOperations.GetBindingExpressionBase(this, EditorEnabledProperty);
+            var bindingExpr = BindingOperations.GetBindingExpressionBase(this, IsEnabledProperty);
             if (bindingExpr != null)
             {
                 bindingExpr.UpdateTarget();
@@ -631,11 +631,11 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid
 
 
         #region IUEditor - Enabled Property (DP)
-        public static readonly DependencyProperty EditorEnabledProperty = DependencyProperty.Register("EditorEnabled", typeof(bool), typeof(DescriptorPropertyDefinitionBase), new UIPropertyMetadata(true));
-        public bool EditorEnabled
+        public static readonly DependencyProperty IsEnabledProperty = DependencyProperty.Register("IsEnabled", typeof(bool), typeof(DescriptorPropertyDefinitionBase), new UIPropertyMetadata(true));
+        public bool IsEnabled
         {
-            get => (bool)GetValue(EditorEnabledProperty);
-            set => SetValue(EditorEnabledProperty, value);
+            get => (bool)GetValue(IsEnabledProperty);
+            set => SetValue(IsEnabledProperty, value);
         }
         #endregion // IUEditor Enabled Property
 
@@ -663,10 +663,10 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid
       BindingOperations.SetBinding( this, DescriptorPropertyDefinitionBase.ValueProperty, valueBinding );
 
             #region IUEditor
-            BindingBase enabledBinding = this.CreateEditorEnabledBinding();
+            BindingBase enabledBinding = this.CreateIsEnabledBinding();
             if (enabledBinding != null)
             {
-                BindingOperations.SetBinding(this, DescriptorPropertyDefinitionBase.EditorEnabledProperty, enabledBinding);
+                BindingOperations.SetBinding(this, DescriptorPropertyDefinitionBase.IsEnabledProperty, enabledBinding);
             }
             #endregion // IUEditor
     }

--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/DescriptorPropertyDefinitionBase.cs
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/DescriptorPropertyDefinitionBase.cs
@@ -129,12 +129,12 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid
 
     protected abstract BindingBase CreateValueBinding();
 
-        // IUEditor start
+        #region IUEditor
         protected abstract BindingBase CreateEditorEnabledBinding();
         public abstract string EditorEnabledPropertyName();
-        // IUEditor end
+        #endregion // IUEditor
 
-    #endregion
+    #endregion // Virtual Methods
 
     #region Internal Methods
 
@@ -237,7 +237,7 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid
       }
     }
 
-        // IUEditor start
+        #region IUEditor
         internal void UpdateEditorEnabledFromSource()
         {
             var bindingExpr = BindingOperations.GetBindingExpressionBase(this, EditorEnabledProperty);
@@ -246,8 +246,7 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid
                 bindingExpr.UpdateTarget();
             }
         }
-        // IUEditor end
-
+        #endregion // IUEditor
 
 
 
@@ -631,16 +630,14 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid
     #endregion //Value Property
 
 
-        // IUEditor Start
-        #region Enabled Property (DP)
+        #region IUEditor - Enabled Property (DP)
         public static readonly DependencyProperty EditorEnabledProperty = DependencyProperty.Register("EditorEnabled", typeof(bool), typeof(DescriptorPropertyDefinitionBase), new UIPropertyMetadata(true));
         public bool EditorEnabled
         {
             get => (bool)GetValue(EditorEnabledProperty);
             set => SetValue(EditorEnabledProperty, value);
         }
-        #endregion // Enabled Property
-        // IUEditor End
+        #endregion // IUEditor Enabled Property
 
     public virtual void InitProperties()
     {
@@ -665,13 +662,13 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid
       BindingBase valueBinding = this.CreateValueBinding();
       BindingOperations.SetBinding( this, DescriptorPropertyDefinitionBase.ValueProperty, valueBinding );
 
-            // IUEditor start
+            #region IUEditor
             BindingBase enabledBinding = this.CreateEditorEnabledBinding();
             if (enabledBinding != null)
             {
                 BindingOperations.SetBinding(this, DescriptorPropertyDefinitionBase.EditorEnabledProperty, enabledBinding);
             }
-            // IUEditor end
+            #endregion // IUEditor
     }
 
 

--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/Editors/TypeEditor.cs
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/Editors/TypeEditor.cs
@@ -68,8 +68,7 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid.Editors
       var _binding = new Binding( "Value" );
       _binding.Source = propertyItem;
       _binding.UpdateSourceTrigger = (Editor is InputBase) ? UpdateSourceTrigger.PropertyChanged : UpdateSourceTrigger.Default;
-            //_binding.Mode = propertyItem.IsReadOnly ? BindingMode.OneWay : BindingMode.TwoWay;
-            _binding.Mode = BindingMode.TwoWay; // IUEditor JB
+      _binding.Mode = propertyItem.IsReadOnly ? BindingMode.OneWay : BindingMode.TwoWay;
       _binding.Converter = CreateValueConverter();
       BindingOperations.SetBinding( Editor, ValueProperty, _binding );
     }
@@ -82,7 +81,7 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid.Editors
             {
                 Source = propertyItem,
                 UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged,
-                Mode = BindingMode.TwoWay
+                Mode = BindingMode.OneWay
             };
             BindingOperations.SetBinding(Editor, UIElement.IsEnabledProperty, _binding);
         }

--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/Editors/TypeEditor.cs
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/Editors/TypeEditor.cs
@@ -45,6 +45,7 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid.Editors
       SetValueDependencyProperty();
       SetControlProperties( propertyItem );
       ResolveValueBinding( propertyItem );
+            ResolveEditorEnabledBinding(propertyItem); // IUEditor
       return Editor;
     }
 
@@ -67,10 +68,25 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid.Editors
       var _binding = new Binding( "Value" );
       _binding.Source = propertyItem;
       _binding.UpdateSourceTrigger = (Editor is InputBase) ? UpdateSourceTrigger.PropertyChanged : UpdateSourceTrigger.Default;
-      _binding.Mode = propertyItem.IsReadOnly ? BindingMode.OneWay : BindingMode.TwoWay;
+            //_binding.Mode = propertyItem.IsReadOnly ? BindingMode.OneWay : BindingMode.TwoWay;
+            _binding.Mode = BindingMode.TwoWay; // IUEditor JB
       _binding.Converter = CreateValueConverter();
       BindingOperations.SetBinding( Editor, ValueProperty, _binding );
     }
+
+        // IUEditor start
+        // TODO: @JB After test,(if successful) promote this method to ITypeEditor for all other editors not inheriting TypeEditor
+        protected void ResolveEditorEnabledBinding(PropertyItem propertyItem)
+        {
+            var _binding = new Binding("EditorEnabled")
+            {
+                Source = propertyItem,
+                UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged,
+                Mode = BindingMode.TwoWay
+            };
+            BindingOperations.SetBinding(Editor, UIElement.IsEnabledProperty, _binding);
+        }
+        // IUEditor end
 
     protected virtual void SetControlProperties( PropertyItem propertyItem )
     {

--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/Editors/TypeEditor.cs
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/Editors/TypeEditor.cs
@@ -46,7 +46,7 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid.Editors
       SetControlProperties( propertyItem );
       ResolveValueBinding( propertyItem );
             #region IUEditor
-            ResolveEditorEnabledBinding(propertyItem);
+            ResolveIsEnabledBinding(propertyItem);
             #endregion // IUEditor
       return Editor;
     }
@@ -76,9 +76,9 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid.Editors
     }
 
         #region IUEditor
-        protected void ResolveEditorEnabledBinding(PropertyItem propertyItem)
+        protected void ResolveIsEnabledBinding(PropertyItem propertyItem)
         {
-            var _binding = new Binding("EditorEnabled")
+            var _binding = new Binding("IsEnabled")
             {
                 Source = propertyItem,
                 UpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged,

--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/Editors/TypeEditor.cs
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/Editors/TypeEditor.cs
@@ -45,7 +45,9 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid.Editors
       SetValueDependencyProperty();
       SetControlProperties( propertyItem );
       ResolveValueBinding( propertyItem );
-            ResolveEditorEnabledBinding(propertyItem); // IUEditor
+            #region IUEditor
+            ResolveEditorEnabledBinding(propertyItem);
+            #endregion // IUEditor
       return Editor;
     }
 
@@ -73,7 +75,7 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid.Editors
       BindingOperations.SetBinding( Editor, ValueProperty, _binding );
     }
 
-        // IUEditor start
+        #region IUEditor
         protected void ResolveEditorEnabledBinding(PropertyItem propertyItem)
         {
             var _binding = new Binding("EditorEnabled")
@@ -84,7 +86,7 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid.Editors
             };
             BindingOperations.SetBinding(Editor, UIElement.IsEnabledProperty, _binding);
         }
-        // IUEditor end
+        #endregion // IUEditor
 
     protected virtual void SetControlProperties( PropertyItem propertyItem )
     {

--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/Editors/TypeEditor.cs
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/Editors/TypeEditor.cs
@@ -74,7 +74,6 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid.Editors
     }
 
         // IUEditor start
-        // TODO: @JB After test,(if successful) promote this method to ITypeEditor for all other editors not inheriting TypeEditor
         protected void ResolveEditorEnabledBinding(PropertyItem propertyItem)
         {
             var _binding = new Binding("EditorEnabled")

--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/ObjectContainerHelperBase.cs
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/ObjectContainerHelperBase.cs
@@ -122,6 +122,17 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid
       }
     }
 
+        // IUEditor start
+        public override void UpdateEditorEnabledFromSource()
+        {
+            foreach(PropertyItem item in PropertyItems)
+            {
+                item.DescriptorDefinition.UpdateEditorEnabledFromSource();
+                item.ContainerHelper.UpdateEditorEnabledFromSource();
+            }
+        }
+        // IUEditor end
+
     public void GenerateProperties()
     {
       if( (PropertyItems.Count == 0)
@@ -398,6 +409,12 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid
       SetupDefinitionBinding( propertyItem, PropertyItemBase.AdvancedOptionsIconProperty, pd, () => pd.AdvancedOptionsIcon, BindingMode.OneWay );
       SetupDefinitionBinding( propertyItem, PropertyItemBase.AdvancedOptionsTooltipProperty, pd, () => pd.AdvancedOptionsTooltip, BindingMode.OneWay );
       SetupDefinitionBinding( propertyItem, PropertyItem.ValueProperty, pd, () => pd.Value, BindingMode.TwoWay );
+            // IUEditor start
+            string editorEnabledPropertyName = pd.EditorEnabledPropertyName();
+            if (editorEnabledPropertyName != null) { 
+                SetupEnabledBiding(propertyItem, pd, "EditorEnabled", BindingMode.TwoWay );
+            }
+            // IUEditor end
 
       if( pd.CommandBindings != null )
       {
@@ -450,6 +467,18 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid
 
       propertyItem.SetBinding( itemProperty, binding );
     }
+
+        // IUEditor start
+        private void SetupEnabledBiding(PropertyItem propertyItem, DescriptorPropertyDefinitionBase pd, string enabledProperty, BindingMode bindingMode)
+        {
+            Binding binding = new Binding(enabledProperty)
+            {
+                Source = pd,
+                Mode = bindingMode
+            };
+            propertyItem.SetBinding(PropertyItem.EditorEnabledProperty, binding);
+        }
+        // IUEditor end
 
     internal FrameworkElement GenerateChildrenEditorElement( PropertyItem propertyItem )
     {

--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/ObjectContainerHelperBase.cs
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/ObjectContainerHelperBase.cs
@@ -122,7 +122,7 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid
       }
     }
 
-        // IUEditor start
+        #region IUEditor
         public override void UpdateEditorEnabledFromSource()
         {
             foreach(PropertyItem item in PropertyItems)
@@ -131,7 +131,7 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid
                 item.ContainerHelper.UpdateEditorEnabledFromSource();
             }
         }
-        // IUEditor end
+        #endregion // IUEditor
 
     public void GenerateProperties()
     {
@@ -409,12 +409,12 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid
       SetupDefinitionBinding( propertyItem, PropertyItemBase.AdvancedOptionsIconProperty, pd, () => pd.AdvancedOptionsIcon, BindingMode.OneWay );
       SetupDefinitionBinding( propertyItem, PropertyItemBase.AdvancedOptionsTooltipProperty, pd, () => pd.AdvancedOptionsTooltip, BindingMode.OneWay );
       SetupDefinitionBinding( propertyItem, PropertyItem.ValueProperty, pd, () => pd.Value, BindingMode.TwoWay );
-            // IUEditor start
+            #region IUEditor
             string editorEnabledPropertyName = pd.EditorEnabledPropertyName();
             if (editorEnabledPropertyName != null) { 
                 SetupEnabledBiding(propertyItem, pd, "EditorEnabled", BindingMode.OneWay );
             }
-            // IUEditor end
+            #endregion // IUEditor
 
       if( pd.CommandBindings != null )
       {
@@ -468,7 +468,7 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid
       propertyItem.SetBinding( itemProperty, binding );
     }
 
-        // IUEditor start
+        #region IUEditor
         private void SetupEnabledBiding(PropertyItem propertyItem, DescriptorPropertyDefinitionBase pd, string enabledProperty, BindingMode bindingMode)
         {
             Binding binding = new Binding(enabledProperty)
@@ -478,7 +478,7 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid
             };
             propertyItem.SetBinding(PropertyItem.EditorEnabledProperty, binding);
         }
-        // IUEditor end
+        #endregion // IUEditor
 
     internal FrameworkElement GenerateChildrenEditorElement( PropertyItem propertyItem )
     {

--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/ObjectContainerHelperBase.cs
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/ObjectContainerHelperBase.cs
@@ -412,7 +412,7 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid
             // IUEditor start
             string editorEnabledPropertyName = pd.EditorEnabledPropertyName();
             if (editorEnabledPropertyName != null) { 
-                SetupEnabledBiding(propertyItem, pd, "EditorEnabled", BindingMode.TwoWay );
+                SetupEnabledBiding(propertyItem, pd, "EditorEnabled", BindingMode.OneWay );
             }
             // IUEditor end
 

--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/ObjectContainerHelperBase.cs
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/ObjectContainerHelperBase.cs
@@ -123,12 +123,12 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid
     }
 
         #region IUEditor
-        public override void UpdateEditorEnabledFromSource()
+        public override void UpdateIsEnabledFromSource()
         {
             foreach(PropertyItem item in PropertyItems)
             {
-                item.DescriptorDefinition.UpdateEditorEnabledFromSource();
-                item.ContainerHelper.UpdateEditorEnabledFromSource();
+                item.DescriptorDefinition.UpdateIsEnabledFromSource();
+                item.ContainerHelper.UpdateIsEnabledFromSource();
             }
         }
         #endregion // IUEditor
@@ -410,9 +410,9 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid
       SetupDefinitionBinding( propertyItem, PropertyItemBase.AdvancedOptionsTooltipProperty, pd, () => pd.AdvancedOptionsTooltip, BindingMode.OneWay );
       SetupDefinitionBinding( propertyItem, PropertyItem.ValueProperty, pd, () => pd.Value, BindingMode.TwoWay );
             #region IUEditor
-            string editorEnabledPropertyName = pd.EditorEnabledPropertyName();
+            string editorEnabledPropertyName = pd.IsEnabledPropertyName();
             if (editorEnabledPropertyName != null) { 
-                SetupEnabledBiding(propertyItem, pd, "EditorEnabled", BindingMode.OneWay );
+                SetupEnabledBiding(propertyItem, pd, "IsEnabled", BindingMode.OneWay );
             }
             #endregion // IUEditor
 
@@ -476,7 +476,7 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid
                 Source = pd,
                 Mode = bindingMode
             };
-            propertyItem.SetBinding(PropertyItem.EditorEnabledProperty, binding);
+            propertyItem.SetBinding(PropertyItem.IsEnabledProperty, binding);
         }
         #endregion // IUEditor
 

--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/PropertyItem.cs
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/PropertyItem.cs
@@ -52,6 +52,25 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid
 
     #endregion //IsReadOnly
 
+        // IUEditor start
+        #region EditorEnabled  
+            // EditorEnabled naming: IsReadOnly는 XCTK에, IsEnabled는 WPF에 원래 있는 이름이어서 EditorEnabled 로 정함
+
+        /// <summary>
+        /// Identifies the EditorEnabled dependency property
+        /// </summary>
+        public static readonly DependencyProperty EditorEnabledProperty =
+            DependencyProperty.Register("EditorEnabled", typeof(bool), typeof(PropertyItem), new UIPropertyMetadata(true));
+
+        public bool EditorEnabled
+        {
+            get { return (bool)GetValue(EditorEnabledProperty); }
+            set { SetValue(EditorEnabledProperty, value); }
+        }
+
+        #endregion //EditorEnabled
+        // IUEditor End
+
     #region PropertyDescriptor
 
     public PropertyDescriptor PropertyDescriptor

--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/PropertyItem.cs
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/PropertyItem.cs
@@ -52,8 +52,7 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid
 
     #endregion //IsReadOnly
 
-        // IUEditor start
-        #region EditorEnabled  
+        #region IUEditor - EditorEnabled  
             // EditorEnabled naming: IsReadOnly는 XCTK에, IsEnabled는 WPF에 원래 있는 이름이어서 EditorEnabled 로 정함
 
         /// <summary>
@@ -67,9 +66,7 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid
             get { return (bool)GetValue(EditorEnabledProperty); }
             set { SetValue(EditorEnabledProperty, value); }
         }
-
-        #endregion //EditorEnabled
-        // IUEditor End
+        #endregion // IUEditor EditorEnabled
 
     #region PropertyDescriptor
 

--- a/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/PropertyItem.cs
+++ b/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.Toolkit/PropertyGrid/Implementation/PropertyItem.cs
@@ -52,21 +52,21 @@ namespace Xceed.Wpf.Toolkit.PropertyGrid
 
     #endregion //IsReadOnly
 
-        #region IUEditor - EditorEnabled  
-            // EditorEnabled naming: IsReadOnly는 XCTK에, IsEnabled는 WPF에 원래 있는 이름이어서 EditorEnabled 로 정함
+        #region IUEditor - IsEnabled  
+            // IsEnabled naming: IsReadOnly는 XCTK에, IsEnabled는 WPF에 원래 있는 이름이어서 IsEnabled 로 정함
 
         /// <summary>
-        /// Identifies the EditorEnabled dependency property
+        /// Identifies the IsEnabled dependency property
         /// </summary>
-        public static readonly DependencyProperty EditorEnabledProperty =
-            DependencyProperty.Register("EditorEnabled", typeof(bool), typeof(PropertyItem), new UIPropertyMetadata(true));
+        public static readonly DependencyProperty IsEnabledProperty =
+            DependencyProperty.Register("IsEnabled", typeof(bool), typeof(PropertyItem), new UIPropertyMetadata(true));
 
-        public bool EditorEnabled
+        public bool IsEnabled
         {
-            get { return (bool)GetValue(EditorEnabledProperty); }
-            set { SetValue(EditorEnabledProperty, value); }
+            get { return (bool)GetValue(IsEnabledProperty); }
+            set { SetValue(IsEnabledProperty, value); }
         }
-        #endregion // IUEditor EditorEnabled
+        #endregion // IUEditor IsEnabled
 
     #region PropertyDescriptor
 


### PR DESCRIPTION
PropertyGrid의 각 PropertyItem의 에디터에 CanChange 바인딩 할 수 있도록 EditorEnabled dependency property를 추가했습니다.
일단 TypeEditor<T>를 상속받는것들에는 바로 적용되고,
ITypeEditor 구현한 커스텀에디터들은 cppiueditor에서 해당 바인딩코드 추가했습니다.

minor)
1. indentation: 기존 wpftoolkit 코드의 인덴트가 1tab=2spaces 로 되어있어서 추가된 코드와 안맞는데, 인덴트가 분리되고 보니 오히려 추가된 코드가 따로 보여서 일부러 이렇게 두었습니다. 요청하시면 전체 Formatting 맞춰서 다시 푸시할게요
2. EditorEnabled 네이밍: IsEnabled 가 원래 UIElement에 있는 속성이고, IsReadOnly가 wpftoolkit propertygrid에 있는 속성이어서, 중복되지 않도록 EditorEnabled 라는 이름으로 프로퍼티를 추가했습니다.